### PR TITLE
Optimize based on ChatGPT recommendations

### DIFF
--- a/src/Provider/RecommendationsProvider.php
+++ b/src/Provider/RecommendationsProvider.php
@@ -87,14 +87,14 @@ SQL;
         unset($orders);
 
         $recommendations = [];
-        foreach ($matrix->getSimilarProducts((int) $productVariant->getId(), $max) as $result) {
-            $variantResult = $this->productVariantRepository->find($result[0]);
+        foreach ($matrix->getSimilarProducts((int) $productVariant->getId(), $max)->getResult() as $result) {
+            $variantResult = $this->productVariantRepository->find($result->subject);
             if (!$variantResult instanceof ProductVariantInterface) {
                 // todo this should be impossible. Should we throw an exception or log it?
                 continue;
             }
 
-            $recommendations[] = new Recommendation($variantResult, $result[1]);
+            $recommendations[] = new Recommendation($variantResult, $result->similarity);
         }
 
         return $recommendations;

--- a/src/Similarity/SimilarityCalculation.php
+++ b/src/Similarity/SimilarityCalculation.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusRecommendationsPlugin\Similarity;
+
+/**
+ * @internal
+ */
+final class SimilarityCalculation
+{
+    public function __construct(public readonly mixed $subject, public readonly float $similarity)
+    {
+    }
+}

--- a/src/Similarity/SimilarityCalculationResult.php
+++ b/src/Similarity/SimilarityCalculationResult.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusRecommendationsPlugin\Similarity;
+
+/**
+ * @internal
+ */
+final class SimilarityCalculationResult
+{
+    private int $index = 0;
+
+    /** @var array<int, SimilarityCalculation> */
+    private array $calculations = [];
+
+    public function __construct(private readonly int $max, private float $similarityThreshold = 0.0)
+    {
+    }
+
+    public function add(SimilarityCalculation $calculation): void
+    {
+        if ($calculation->similarity <= $this->similarityThreshold) {
+            return;
+        }
+
+        $this->calculations[$this->index++] = $calculation;
+
+        if ($this->index >= 2 * $this->max) {
+            $this->sort();
+        }
+    }
+
+    /**
+     * @return array<int, SimilarityCalculation>
+     */
+    public function getResult(): array
+    {
+        $this->sort();
+
+        return $this->calculations;
+    }
+
+    private function sort(): void
+    {
+        usort(
+            $this->calculations,
+            static fn (SimilarityCalculation $a, SimilarityCalculation $b) => $b->similarity <=> $a->similarity,
+        );
+
+        if (isset($this->calculations[$this->max])) {
+            $this->similarityThreshold = $this->calculations[$this->max]->similarity;
+        }
+
+        $this->calculations = array_slice($this->calculations, 0, $this->max);
+        $this->index = count($this->calculations);
+    }
+}

--- a/tests/Matrix/OrderProductMatrixTest.php
+++ b/tests/Matrix/OrderProductMatrixTest.php
@@ -6,6 +6,7 @@ namespace Setono\SyliusRecommendationsPlugin\Tests\Matrix;
 
 use PHPUnit\Framework\TestCase;
 use Setono\SyliusRecommendationsPlugin\Matrix\OrderProductMatrix;
+use Setono\SyliusRecommendationsPlugin\Similarity\SimilarityCalculation;
 
 final class OrderProductMatrixTest extends TestCase
 {
@@ -34,11 +35,11 @@ final class OrderProductMatrixTest extends TestCase
         $matrix->addOrder([102, 103, 104]);
         $matrix->addOrder([105]); // product 105 should have a similarity of 0 with product 102 because it has never been bought together
 
-        self::assertSame([
-            [100, 0.8164965809277259],
-            [101, 0.5773502691896258],
-            [103, 0.5773502691896258],
-            [104, 0.5773502691896258],
-        ], $matrix->getSimilarProducts(102, 10));
+        self::assertEquals([
+            new SimilarityCalculation(100, 0.8164965809277259),
+            new SimilarityCalculation(101, 0.5773502691896258),
+            new SimilarityCalculation(103, 0.5773502691896258),
+            new SimilarityCalculation(104, 0.5773502691896258),
+        ], $matrix->getSimilarProducts(102, 10)->getResult());
     }
 }

--- a/tests/Similarity/SimilarityCalculationResultTest.php
+++ b/tests/Similarity/SimilarityCalculationResultTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusRecommendationsPlugin\Tests\Similarity;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusRecommendationsPlugin\Similarity\SimilarityCalculation;
+use Setono\SyliusRecommendationsPlugin\Similarity\SimilarityCalculationResult;
+
+final class SimilarityCalculationResultTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_a_maximum_number_of_results(): void
+    {
+        $result = new SimilarityCalculationResult(3);
+        $result->add($expected3 = new SimilarityCalculation(1, 0.5));
+        $result->add(new SimilarityCalculation(2, 0.4));
+        $result->add($expected2 = new SimilarityCalculation(3, 0.6));
+        $result->add(new SimilarityCalculation(4, 0.2));
+        $result->add($expected1 = new SimilarityCalculation(5, 0.8));
+
+        self::assertCount(3, $result->getResult());
+        self::assertSame([$expected1, $expected2, $expected3], $result->getResult());
+    }
+}


### PR DESCRIPTION
I pasted the `OrderProductMatrix` class to ChatGPT and asked it for optimizations. Here was the output:

```
Optimizing the given PHP code involves focusing on reducing computational complexity and improving the efficiency of data handling. Here are some suggestions:

Optimize addOrder Method:
- Currently, it's efficient, but ensure product IDs are unique within an order to avoid redundant operations if the same product is listed multiple times.

Optimize getSimilarProducts Method:
- The double loop for creating vectors is expensive. You can optimize it by tracking orders each product is in as they are added.
- Use bitwise operations for vector calculations if possible, though this might require a significant change in how you store and process data.

Optimize Vector Creation:
- You can optimize the creation of $vectors by doing it as orders are added, rather than each time getSimilarProducts is called. This way, you avoid recalculating vectors for every query.

Reduce Redundant Checks:
- The check for $product === $targetProduct can be done earlier to avoid unnecessary operations.
- The check if (!isset($vectors[$targetProduct])) can be moved outside the loop since it does not depend on the loop variable.

Improve Cosine Similarity Calculation:
- The cosine similarity calculation does not need to iterate over all orders. Instead, iterate over the non-zero elements of the vectors. This reduces the computation from O(n) to O(k), where k is the number of non-zero elements, which is usually much smaller than n, the total number of orders.

Memoization:
- If getSimilarProducts is called multiple times with the same $targetProduct and $max, consider caching the results. This avoids recalculating similarity scores for the same inputs.

Optimize Sorting and Slicing:
- The current sorting with usort and then slicing with array_slice is efficient. Ensure you're only sorting if necessary and consider using a partial sort if available in PHP to only sort the top $max elements.

Code Review for render Method:
- The render method is straightforward, but ensure that converting product presence to an integer ((int) in_array($product, $row)) is necessary. If you're only displaying it, consider directly printing boolean values or using a ternary operator for readability.

General PHP Optimizations:
- Use PHP 7.4 or later for typed properties for better performance.
- Consider JIT compilation available from PHP 8 if your application's bottleneck is CPU-bound.

Implementing these changes requires careful consideration of the overall architecture and data flow of your application. Always benchmark performance improvements in the context of your specific use case.
```